### PR TITLE
add dependabot automerge as common action

### DIFF
--- a/.github/workflows/dependabot_automerge.yml
+++ b/.github/workflows/dependabot_automerge.yml
@@ -1,0 +1,25 @@
+name: Automerge dependabot
+permissions:
+  id-token: write
+  contents: write
+on:
+  workflow_call:
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1.1.1
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+      - name: Enable auto-merge for Dependabot PRs
+        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
## Ticket
None

## Goal
Use single implementation for automerge of dependabot in all repositories

## UX Changes
None

## Code Changes
- Add shared workflow for dependabot

## Related Pull Requests
None

## Notes & Questions for Reviewers

### Checks
- [x] Changes in this PR follows Haus' [code contribution guidelines](https://docs.google.com/document/d/1-3pOkN0Qk5OrsoDJCFPL_Jwunc6ptXLzSpTdTRAH7to/edit#heading=h.fy8j7l7xqyx8) or if it breaks guidelines I've explained why it's necessary.
- [ ] I'm making a #major or #minor [semver](https://semver.org/) change and have that [present](https://github.com/jasonamyers/github-bumpversion-action) in a commit message
