### PR TITLE
use pre-commit action instead of homebrewed version

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,9 +12,4 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.9'
-    - name: Install Poetry
-      uses: snok/install-poetry@v1
-    - name: Install dependencies
-      run: poetry install --no-interaction
-    - name: Run pre-commit
-      run: poetry run pre-commit run --all-files
+    - uses: pre-commit/action@v3.0.0


### PR DESCRIPTION
## Ticket
None

## Goal
Use pre-commit github action to reduce amount of time it takes to run pre-commits.

## UX Changes
None

## Code Changes
use github action provided by pre-commit.

## Related Pull Requests
None
## Notes & Questions for Reviewers
It is a deprecated github action because they have their own CI/CD they try to lure people into.
### Checks
- [ ] Changes in this PR follows Haus' [code contribution guidelines](https://docs.google.com/document/d/1-3pOkN0Qk5OrsoDJCFPL_Jwunc6ptXLzSpTdTRAH7to/edit#heading=h.fy8j7l7xqyx8) or if it breaks guidelines I've explained why it's necessary.
- [ ] I'm making a #major or #minor [semver](https://semver.org/) change and have that [present](https://github.com/jasonamyers/github-bumpversion-action) in a commit message
