### PR TITLE
Add job to create release

### DIFF
--- a/.github/workflows/bump_and_tag_with_google_creds.yml
+++ b/.github/workflows/bump_and_tag_with_google_creds.yml
@@ -19,6 +19,9 @@ jobs:
   bump-and-tag:
     timeout-minutes: 3
     runs-on: ubuntu-latest
+    outputs:
+      new_ver: ${{ steps.bump_version.outputs.new_ver }}
+      old_ver: ${{ steps.bump_version.outputs.old_ver }}
     steps:
     - name: Auth with GCP
       uses: google-github-actions/auth@v0.8.0
@@ -49,3 +52,18 @@ jobs:
         force: true
         branch: ${{ github.ref }}
         tags: true
+  create-release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    needs: bump-and-tag
+    steps:
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1.1.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions
+        with:
+          tag_name: v${{ needs.bump-and-tag.outputs.new_ver }}
+          release_name: Release v${{ needs.bump-and-tag.outputs.new_ver }}
+          draft: false
+          prerelease: false


### PR DESCRIPTION
## Ticket
https://app.asana.com/0/0/1203536278220560/f
## Goal
Regiontest hasn't had working release logic for awhile. https://github.com/HausAnalytics/regiontest
I meant to come back to this and never did

## Code Changes
use github's release action
## Related Pull Requests

## How I Know This Works
I dont. I'll test and be quick with reverting if it doesnt

## Notes & Questions for Reviewers

### Checks
- [x] Changes in this PR follows Haus' [code contribution guidelines](https://docs.google.com/document/d/1-3pOkN0Qk5OrsoDJCFPL_Jwunc6ptXLzSpTdTRAH7to/edit#heading=h.fy8j7l7xqyx8) or if it breaks guidelines I've explained why it's necessary.
- [ ] I'm making a #major or #minor [semver](https://semver.org/) change and have that [present](https://github.com/jasonamyers/github-bumpversion-action) in a commit message
