### PR TITLE
Update set output to new syntax

### DIFF
--- a/.github/workflows/post_slack_deploy_message.yml
+++ b/.github/workflows/post_slack_deploy_message.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
     # Post deploy to slack
     - name: Auth with GCP
-      uses: 'google-github-actions/auth@v0.8.0'
+      uses: 'google-github-actions/auth@v1'
       with:
         workload_identity_provider: ${{ inputs.workload_identity_provider }}
         service_account: ${{ inputs.service_account }}
@@ -66,9 +66,9 @@ jobs:
     - name: "Set PR data as output variables"
       id: pr_data
       run: |
-        echo ::set-output name=pr_title::${{fromJson(steps.get_pr_info.outputs.data)[0].title}}
-        echo ::set-output name=pr_url::${{fromJson(steps.get_pr_info.outputs.data)[0].html_url}}
-        echo ::set-output name=author::${{fromJson(steps.get_pr_info.outputs.data)[0].user.login}}
+        echo "{pr_title}=${{fromJson(steps.get_pr_info.outputs.data)[0].title}}" >> $GITHUB_OUTPUT
+        echo "{pr_url}=${{fromJson(steps.get_pr_info.outputs.data)[0].html_url}}" >> $GITHUB_OUTPUT
+        echo "{author}=${{fromJson(steps.get_pr_info.outputs.data)[0].user.login}}" >> $GITHUB_OUTPUT
     - name: Post to slack channel
       uses: slackapi/slack-github-action@v1.21.0
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_STORE


### PR DESCRIPTION
## Ticket
https://app.asana.com/0/1201247707079024/1203218390475803/f
## Goal
Update root slack message to use new set output syntax https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
upgrade auth to 1 that's compatible with new set output syntax https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## Code Changes

## How I Know This Works
dunno yet
## Notes & Questions for Reviewers

### Checks
- [x] Changes in this PR follows Haus' [code contribution guidelines](https://docs.google.com/document/d/1-3pOkN0Qk5OrsoDJCFPL_Jwunc6ptXLzSpTdTRAH7to/edit#heading=h.fy8j7l7xqyx8) or if it breaks guidelines I've explained why it's necessary.
- [ ] I'm making a #major or #minor [semver](https://semver.org/) change and have that [present](https://github.com/jasonamyers/github-bumpversion-action) in a commit message
